### PR TITLE
add `customIgnored`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Unleash the full potential of your Strapi content with nested, customizable popu
 
     `/api/pages?customPopulate=nested&customDepth=4`
 
+  - Ignore custom properties
+
+    `/api/pages?customPopulate=nested&customIgnored[]=images&customIgnored[]=videos`
+
 ## Good to know
 
   - Default maximum depth: 6 levels

--- a/main/configuration/index.js
+++ b/main/configuration/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   default: {
     defaultDepth: 6,
+    ignore: [],
     skipCreatorFields: true,
   },
   validator: () => { },

--- a/main/framework.js
+++ b/main/framework.js
@@ -9,17 +9,23 @@ module.exports = ({ strapi }) => {
 
     // Only proceed for 'beforeFindMany' or 'beforeFindOne' actions.
     if (action === 'beforeFindMany' || action === 'beforeFindOne') {
-      const { customPopulate, customDepth } = params || {};
+      const { customPopulate, customDepth, customIgnored } = params || {};
 
       // Get the default depth from plugin config, fallback to 5 if undefined.
       const defaultDepth = strapi
         .plugin('strapi-plugin-nested-populator')
         ?.config('defaultDepth') || 5;
 
+      // Get the default ignored list from plugin config, fallback to empty array if undefined.
+      const defaultIgnored = strapi
+        .plugin('strapi-plugin-nested-populator')
+        ?.config('ignore') || [];
+
       // Apply population logic if 'nested' population is requested.
       if (customPopulate === 'nested') {
         const depth = customDepth > 0 ? customDepth : defaultDepth;
-        const modelObject = buildPopulateTree(model.uid, depth, []);
+        const ignored = customIgnored || defaultIgnored;
+        const modelObject = buildPopulateTree(model.uid, depth, ignored);
 
         // Update the event params with the computed population object.
         params.populate = modelObject.populate;


### PR DESCRIPTION
Hey EncoreSky,

First of all, thank you for this strapi plugin!

I was using your package and I needed a way to ignore some fields.
I added a `customIgnored` property because the `buildPopulateTree` function already had an input for something like it.

I think this should be merged, we're just exposing something that is already implemented. 